### PR TITLE
Add statistical feature modules and config

### DIFF
--- a/feature_extraction/__init__.py
+++ b/feature_extraction/__init__.py
@@ -1,0 +1,5 @@
+from .time_skewness import time_skewness
+from .time_kurtosis import time_kurtosis
+from .wavelet_features import wavelet_energy
+
+__all__ = ["time_skewness", "time_kurtosis", "wavelet_energy"]

--- a/feature_extraction/time_kurtosis.py
+++ b/feature_extraction/time_kurtosis.py
@@ -1,0 +1,14 @@
+import math
+
+
+def time_kurtosis(signal):
+    """Return the kurtosis of a 1-D sequence (not excess)."""
+    data = [float(x) for x in signal]
+    n = len(data)
+    mean = sum(data) / n
+    var = sum((x - mean) ** 2 for x in data) / n
+    std = math.sqrt(var)
+    if std == 0:
+        return 0.0
+    fourth = sum((x - mean) ** 4 for x in data) / n
+    return fourth / (std ** 4)

--- a/feature_extraction/time_skewness.py
+++ b/feature_extraction/time_skewness.py
@@ -1,0 +1,14 @@
+import math
+
+
+def time_skewness(signal):
+    """Return the skewness of a 1-D sequence."""
+    data = [float(x) for x in signal]
+    n = len(data)
+    mean = sum(data) / n
+    var = sum((x - mean) ** 2 for x in data) / n
+    std = math.sqrt(var)
+    if std == 0:
+        return 0.0
+    third = sum((x - mean) ** 3 for x in data) / n
+    return third / (std ** 3)

--- a/feature_extraction/wavelet_features.py
+++ b/feature_extraction/wavelet_features.py
@@ -1,0 +1,27 @@
+import math
+
+
+def _haar_level(signal):
+    """One level Haar transform for a sequence."""
+    data = [float(x) for x in signal]
+    if len(data) % 2:
+        data.append(data[-1])
+    cA = []
+    cD = []
+    for i in range(0, len(data), 2):
+        avg = (data[i] + data[i + 1]) / math.sqrt(2.0)
+        diff = (data[i] - data[i + 1]) / math.sqrt(2.0)
+        cA.append(avg)
+        cD.append(diff)
+    return cA, cD
+
+
+def wavelet_energy(signal, level=3):
+    """Compute energies of Haar wavelet coefficients up to given level."""
+    coeff = [float(x) for x in signal]
+    energies = {}
+    for lvl in range(1, level + 1):
+        coeff, detail = _haar_level(coeff)
+        energies[f'D{lvl}'] = sum(d * d for d in detail)
+    energies[f'A{level}'] = sum(c * c for c in coeff)
+    return energies

--- a/ml/config.yaml
+++ b/ml/config.yaml
@@ -1,0 +1,7 @@
+# Default configuration for feature extraction
+features:
+  enable_all: true
+  available:
+    - time_skewness
+    - time_kurtosis
+    - wavelet_energy

--- a/unitest/test_features.py
+++ b/unitest/test_features.py
@@ -1,0 +1,22 @@
+from feature_extraction import time_skewness, time_kurtosis, wavelet_energy
+import random
+
+
+def test_time_skewness_zero_for_symmetric_data():
+    data = [-1, 0, 1]
+    assert abs(time_skewness(data)) < 1e-9
+
+
+def test_time_kurtosis_known_value():
+    data = [-1, 0, 1]
+    expected = 1.5
+    assert abs(time_kurtosis(data) - expected) < 1e-9
+
+
+def test_wavelet_energy_conservation():
+    random.seed(0)
+    data = [random.random() for _ in range(16)]
+    energies = wavelet_energy(data, level=2)
+    total = sum(energies.values())
+    expected = sum(x * x for x in data)
+    assert abs(total - expected) < 1e-6


### PR DESCRIPTION
## Summary
- implement `time_skewness`, `time_kurtosis`, and simple Haar `wavelet_energy`
- expose features in `feature_extraction` package
- add tests covering these new functions
- add sample `ml/config.yaml` enabling the new features

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebdb9d424832587693e5509aa5281