### PR TITLE
Add checkpoint support for XGBoost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Partial Discharge Compare
+
+This repository contains a simple machine learning workflow implemented in the `ml_flow` package. It demonstrates loading a dataset, optional feature selection, hyper-parameter tuning and training multiple models.
+
+## Running the workflow
+
+```bash
+python ml_flow/main.py --config ml_flow/config.json
+```
+
+Edit `config.json` to control dataset, models and other options.
+
+## Checkpointing and Resuming
+
+`train_model` now supports saving intermediate checkpoints when training XGBoost models. Two new configuration keys are available:
+
+- `checkpoint_interval`: save a checkpoint every _N_ boosting rounds. Set to `null` to disable.
+- `resume_training`: if `true`, the trainer will resume from the latest checkpoint in the `model` directory when training an XGBoost model.
+
+Example excerpt in `config.json`:
+
+```json
+{
+  "checkpoint_interval": 10,
+  "resume_training": true
+}
+```
+
+Checkpoints are stored in `model` with filenames like `XGBoost_checkpoint_10.json`. To start training from scratch, delete existing checkpoint files or set `resume_training` to `false`.

--- a/ml_flow/config.json
+++ b/ml_flow/config.json
@@ -11,5 +11,7 @@
   "test_size": 0.2,
   "val_size": 0.2,
   "random_state": 42,
-  "target_column": "target"
+  "target_column": "target",
+  "checkpoint_interval": null,
+  "resume_training": false
 }

--- a/ml_flow/main.py
+++ b/ml_flow/main.py
@@ -90,7 +90,15 @@ def main():
                     best_params = None # Use default parameters in train_model
 
                 # 5. Model Training
-                model, cv_score = train_model(X_train, y_train, model_type=model_type, params=best_params, cv=config.get('cv_folds'))
+                model, cv_score = train_model(
+                    X_train,
+                    y_train,
+                    model_type=model_type,
+                    params=best_params,
+                    cv=config.get('cv_folds'),
+                    checkpoint_interval=config.get('checkpoint_interval'),
+                    resume=config.get('resume_training'),
+                )
 
                 # 6. Model Evaluation
                 accuracy, roc_auc, precision, recall, f1, conf_matrix = evaluate_model(model, X_test, y_test)

--- a/ml_flow/model_runner.py
+++ b/ml_flow/model_runner.py
@@ -4,38 +4,104 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 import xgboost as xgb
 from sklearn.model_selection import cross_val_score, train_test_split
-from sklearn.metrics import accuracy_score, classification_report, roc_auc_score, precision_score, recall_score, f1_score, confusion_matrix
+from sklearn.metrics import (
+    accuracy_score,
+    classification_report,
+    roc_auc_score,
+    precision_score,
+    recall_score,
+    f1_score,
+    confusion_matrix,
+)
 import logging
 import pickle
 import os
 
+
+class XGBoostCheckpoint(xgb.callback.TrainingCallback):
+    """Callback for saving XGBoost checkpoints."""
+
+    def __init__(self, model_dir, interval, prefix):
+        self.model_dir = model_dir
+        self.interval = interval
+        self.prefix = prefix
+
+    def after_iteration(self, model, epoch, evals_log):
+        if (epoch + 1) % self.interval == 0:
+            os.makedirs(self.model_dir, exist_ok=True)
+            path = os.path.join(self.model_dir, f"{self.prefix}_{epoch + 1}.json")
+            model.save_model(path)
+        return False
+
+
+def _latest_checkpoint(model_dir, prefix):
+    """Return the latest checkpoint path if available."""
+    if not os.path.isdir(model_dir):
+        return None
+    checkpoints = [
+        os.path.join(model_dir, f)
+        for f in os.listdir(model_dir)
+        if f.startswith(prefix)
+    ]
+    if not checkpoints:
+        return None
+    return max(checkpoints, key=os.path.getmtime)
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-def train_model(X_train, y_train, model_type='DecisionTree', params=None, cv=5, scoring='accuracy', model_dir='model'):
+def train_model(
+    X_train,
+    y_train,
+    model_type='DecisionTree',
+    params=None,
+    cv=5,
+    scoring='accuracy',
+    model_dir='model',
+    checkpoint_interval=None,
+    resume=False,
+):
     """
     Trains and evaluates a machine learning model using cross-validation.
     Saves the trained model to model_dir.
     """
     logging.info(f"Training {model_type} model...")
     if model_type == 'DecisionTree':
-        model = DecisionTreeClassifier(**(params or {})) # Use params if provided, else default
+        model_cls = DecisionTreeClassifier
     elif model_type == 'SVM':
-        model = SVC(**(params or {}), probability=True) # probability=True for ROC AUC
+        model_cls = SVC
     elif model_type == 'RandomForest':
-        model = RandomForestClassifier(**(params or {}))
+        model_cls = RandomForestClassifier
     elif model_type == 'XGBoost':
-        model = xgb.XGBClassifier(**(params or {}))
+        model_cls = xgb.XGBClassifier
     elif model_type == 'LogisticRegression':
-        model = LogisticRegression(**(params or {}))
+        model_cls = LogisticRegression
     else:
         raise ValueError(f"Model type '{model_type}' not supported.")
 
-    cv_scores = cross_val_score(model, X_train, y_train, cv=cv, scoring=scoring)
+    base_model = model_cls(**(params or {}))
+
+    cv_scores = cross_val_score(base_model, X_train, y_train, cv=cv, scoring=scoring)
     logging.info(f"Cross-validation scores ({scoring}): {cv_scores}")
     logging.info(f"Mean CV score ({scoring}): {cv_scores.mean():.4f}")
 
-    model.fit(X_train, y_train) # Fit on the entire training set after CV
+    fit_kwargs = {}
+    callbacks = []
+    if model_type == 'XGBoost':
+        if checkpoint_interval:
+            callbacks.append(
+                XGBoostCheckpoint(model_dir, checkpoint_interval, f"{model_type}_checkpoint")
+            )
+        if resume:
+            ckpt = _latest_checkpoint(model_dir, f"{model_type}_checkpoint")
+            if ckpt:
+                logging.info(f"Resuming from checkpoint {ckpt}")
+                fit_kwargs['xgb_model'] = ckpt
+        if callbacks:
+            fit_kwargs['callbacks'] = callbacks
+
+    model = model_cls(**(params or {}))
+    model.fit(X_train, y_train, **fit_kwargs)  # Fit on the entire training set after CV
 
     os.makedirs(model_dir, exist_ok=True) # Ensure model directory exists
     model_path = os.path.join(model_dir, f'{model_type}_model.pkl')


### PR DESCRIPTION
## Summary
- create README with checkpoint instructions
- allow training to save and resume XGBoost checkpoints
- pass new options from config
- expose checkpoint settings in config.json

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python ml_flow/main.py --config ml_flow/config.json` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ebdc731e483258f2ec77e5aa7ef84