### PR TITLE
Add checkpointing and resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ test_size: 0.2
 val_size: 0.2
 random_state: 42
 target_column: target
+checkpoint_interval: 10  # save XGBoost checkpoint every 10 rounds
+resume: false            # resume training from the latest checkpoint
 ```
+
+Set ``checkpoint_interval`` to a positive integer to periodically save
+XGBoost checkpoints. Enable ``resume`` to continue training from the
+latest checkpoint if one exists in the ``model`` directory.
 
 Each entry under `datasets` specifies the dataset `path` and an optional
 `label_mapping` used to remap values in the target column.

--- a/ml/config.json
+++ b/ml/config.json
@@ -12,4 +12,6 @@
   "val_size": 0.2,
   "random_state": 42,
   "target_column": "target"
+  ,"checkpoint_interval": 10,
+  "resume": false
 }

--- a/ml/config.yaml
+++ b/ml/config.yaml
@@ -25,3 +25,5 @@ test_size: 0.2
 val_size: 0.2
 random_state: 42
 target_column: target
+checkpoint_interval: 10
+resume: false

--- a/ml/main.py
+++ b/ml/main.py
@@ -125,6 +125,8 @@ def main():
                         model_type=model_type,
                         params=best_params,
                         cv=config.get('cv_folds'),
+                        checkpoint_interval=config.get('checkpoint_interval'),
+                        resume=config.get('resume'),
                     )
 
                     # 6. Model Evaluation


### PR DESCRIPTION
## Summary
- allow optional checkpoints and resume support in `train_model`
- expose checkpoint settings from config and main workflow
- document checkpoint usage
- update example configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'feature_extraction')*

------
https://chatgpt.com/codex/tasks/task_e_685fd0b1d9c083258ab716bec57a9624