### PR TITLE
Refactor preprocessing for station-based dataset

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@
 # 1. Project‑wide paths & runtime options
 # -------------------------------------------------------------------
 project:
-  root_dir: "project_pd"                         # Relocatable root folder
+  root_dir: "partial_discharge_project"         # Relocatable root folder
   raw_data_dir: "data/raw"                      # Raw PD sensor recordings
   processed_dir: "data/processed"               # Cleaned & windowed arrays
   features_dir: "outputs/features"              # Per‑window features & master Parquet
@@ -27,6 +27,8 @@ datasets:
   - path: wine                                    # Wine quality (multi‑class)
     label_mapping: {}
   - path: breast_cancer                           # Binary classification
+    label_mapping: {}
+  - path: dataset/contactless_pd_detection       # Contactless PD signals
     label_mapping: {}
 
 # -------------------------------------------------------------------

--- a/notebooks/cleaning_tutorial.ipynb
+++ b/notebooks/cleaning_tutorial.ipynb
@@ -5,7 +5,8 @@
    "metadata": {},
    "source": [
     "# Cleaning Functions Tutorial\n",
-    "This notebook demonstrates usage of the preprocessing cleaning helpers."
+    "This notebook demonstrates usage of the preprocessing cleaning helpers.",
+    "\nRaw signals are organised under `dataset/contactless_pd_detection/station_<id>/*.npy`. The cleaned outputs are saved under `partial_discharge_project/station_<id>/data_clean/`."
    ]
   },
   {
@@ -21,7 +22,8 @@
     "filt = cleaning.bandpass_filter(signal, 1.0, 30.0, fs=100.0)\n",
     "den = cleaning.advanced_denoise(filt, method='ewt')\n",
     "norm = cleaning.zscore_normalize(den)\n",
-    "norm[:5]"
+    "norm[:5]",
+    "\ncleaning.save_cleaned_signal(norm, 'station_demo', 'standard_denoising_normalisation', 'demo_signal')"
    ]
   }
  ],

--- a/preprocess/cleaning.py
+++ b/preprocess/cleaning.py
@@ -16,28 +16,30 @@ from scipy.signal import butter, filtfilt
 import config
 
 
-def save_cleaned_signal(x: np.ndarray, clean_type: str, dataset: str, window_id: str) -> Path:
-    """Save a cleaned signal to the processed data directory.
+def save_cleaned_signal(x: np.ndarray, station_id: str, sub_dir: str, file_id: str) -> Path:
+    """Save a cleaned signal under the station's data_clean folder.
 
     Parameters
     ----------
     x:
         Array containing the cleaned signal.
-    clean_type:
-        Name of the cleaning method (e.g. ``bandpass`` or ``denoise``).
-    dataset:
-        Dataset name used to create the subdirectory.
-    window_id:
-        Identifier for the sample/window.
+    station_id:
+        Name of the measurement station, e.g. ``"station_52009"``.
+    sub_dir:
+        Relative directory inside ``data_clean`` describing the step,
+        such as ``"standard_denoising_normalisation"`` or
+        ``"advanced_denoising/VMD"``.
+    file_id:
+        Identifier for the file or window.
 
     Returns
     -------
     Path
         Location of the saved file.
     """
-    out_dir = config.PROCESSED_DIR / clean_type / dataset
+    out_dir = config.ROOT_DIR / station_id / "data_clean" / sub_dir
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{window_id}.npy"
+    out_path = out_dir / f"{file_id}.npy"
     np.save(out_path, x)
     return out_path
 

--- a/preprocess/discovery.py
+++ b/preprocess/discovery.py
@@ -12,6 +12,9 @@ import config
 
 Session = namedtuple("Session", ["cable_id", "sensor_files", "label_file"])
 
+# One record per raw ``.npy`` file discovered in the contactless dataset
+FileRecord = namedtuple("FileRecord", ["station_id", "file_path"])
+
 
 def discover_sessions(dataset: str) -> List[Session]:
     """Find all recording sessions in ``data/raw/{dataset}``.
@@ -49,3 +52,17 @@ def discover_sessions(dataset: str) -> List[Session]:
             )
         )
     return sessions
+
+
+def discover_npy_files(dataset_path: str | Path) -> List[FileRecord]:
+    """Discover raw ``.npy`` files organised by station folders."""
+    base = Path(dataset_path)
+    records: List[FileRecord] = []
+    if not base.exists():
+        return records
+    for station_dir in sorted(base.glob("station_*")):
+        if not station_dir.is_dir():
+            continue
+        for file in station_dir.glob("*.npy"):
+            records.append(FileRecord(station_id=station_dir.name, file_path=str(file)))
+    return records

--- a/preprocess/io.py
+++ b/preprocess/io.py
@@ -26,3 +26,11 @@ def load_pd_hdf5(path: str | Path | None) -> np.ndarray:
         key = list(fh.keys())[0]
         data = np.asarray(fh[key])
     return data.astype(float).ravel()
+
+
+def load_pd_npy(path: str | Path | None) -> np.ndarray:
+    """Load a NumPy ``.npy`` file as a 1D array."""
+    if path is None:
+        return np.array([])
+    data = np.load(path)
+    return data.astype(float).ravel()

--- a/preprocess/run_preprocess.py
+++ b/preprocess/run_preprocess.py
@@ -34,16 +34,17 @@ def process_session(session: discovery.Session, dataset: str, force: bool, adv_d
             config.CONFIG.preprocessing_options.bandpass_hz[1],
             fs,
         )
-        cleaning.save_cleaned_signal(x_bp, "bandpass", dataset, window_id_base)
+        cleaning.save_cleaned_signal(x_bp, session.cable_id, "standard_denoising_normalisation", f"{window_id_base}_bp")
 
         if adv_denoise:
             x_den = cleaning.advanced_denoise(x_bp)
-            cleaning.save_cleaned_signal(x_den, "denoise", dataset, window_id_base)
+            method_dir = "advanced_denoising/VMD"
+            cleaning.save_cleaned_signal(x_den, session.cable_id, method_dir, f"{window_id_base}_den")
         else:
             x_den = x_bp
 
         x_norm = cleaning.zscore_normalize(x_den)
-        cleaning.save_cleaned_signal(x_norm, "normalised", dataset, window_id_base)
+        cleaning.save_cleaned_signal(x_norm, session.cable_id, "standard_denoising_normalisation", f"{window_id_base}_norm")
 
         if augment:
             x_aug = augmentation.time_warp(x_norm)
@@ -58,7 +59,7 @@ def process_session(session: discovery.Session, dataset: str, force: bool, adv_d
         )
         labels = windowing.load_window_labels(session.label_file, len(windows))
 
-        out_dir = config.PROCESSED_DIR / dataset / sensor
+        out_dir = config.PROCESSED_DIR / session.cable_id / sensor
         out_dir.mkdir(parents=True, exist_ok=True)
 
         for idx, (win, label) in enumerate(zip(windows, labels)):
@@ -71,8 +72,59 @@ def process_session(session: discovery.Session, dataset: str, force: bool, adv_d
                     fh.write(str(label))
 
 
+def process_npy_file(record: discovery.FileRecord, force: bool, adv_denoise: bool, augment: bool) -> None:
+    """Process a single raw ``.npy`` file from a station."""
+    x = io.load_pd_npy(record.file_path)
+    fs = 1.0  # placeholder sampling rate
+    fid = Path(record.file_path).stem
+
+    x_bp = cleaning.bandpass_filter(
+        x,
+        config.CONFIG.preprocessing_options.bandpass_hz[0],
+        config.CONFIG.preprocessing_options.bandpass_hz[1],
+        fs,
+    )
+    cleaning.save_cleaned_signal(x_bp, record.station_id, "standard_denoising_normalisation", f"{fid}_bp")
+
+    if adv_denoise:
+        x_den = cleaning.advanced_denoise(x_bp)
+        method_dir = "advanced_denoising/VMD"
+        cleaning.save_cleaned_signal(x_den, record.station_id, method_dir, f"{fid}_den")
+    else:
+        x_den = x_bp
+
+    x_norm = cleaning.zscore_normalize(x_den)
+    cleaning.save_cleaned_signal(x_norm, record.station_id, "standard_denoising_normalisation", f"{fid}_norm")
+
+    if augment:
+        x_aug = augmentation.time_warp(x_norm)
+        x_aug = augmentation.add_jitter(x_aug)
+    else:
+        x_aug = x_norm
+
+    windows = windowing.segment_signal(
+        x_aug,
+        config.CONFIG.preprocessing_options.window_length_ms,
+        fs,
+    )
+
+    out_dir = config.PROCESSED_DIR / record.station_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, win in enumerate(windows):
+        out_path = out_dir / f"{fid}_{idx}.npy"
+        if out_path.exists() and not force:
+            continue
+        np.save(out_path, win)
+
+
 def run(dataset: str, force: bool, adv_denoise: bool, augment: bool) -> None:
     """Run preprocessing for ``dataset``."""
+    records = discovery.discover_npy_files(dataset)
+    if records:
+        for rec in records:
+            process_npy_file(rec, force, adv_denoise, augment)
+        return
+
     sessions = discovery.discover_sessions(dataset)
     for session in sessions:
         process_session(session, dataset, force, adv_denoise, augment)

--- a/unitest/test_config.py
+++ b/unitest/test_config.py
@@ -7,5 +7,5 @@ import config
 
 def test_load_config() -> None:
     cfg = config.load_config(Path(__file__).resolve().parents[1] / "config.yaml")
-    assert cfg.project.root_dir == "project_pd"
+    assert cfg.project.root_dir == "partial_discharge_project"
     assert isinstance(config.ROOT_DIR, Path)


### PR DESCRIPTION
## Summary
- update project root in `config.yaml` and add new dataset entry for station data
- adjust cleaning utilities to save results under `station_xxx/data_clean`
- extend discovery and preprocessing to handle `*.npy` files organised by station folders
- update I/O with a loader for npy signals
- tweak test expectation for new root path
- add dataset structure notes in `cleaning_tutorial.ipynb`

## Testing
- `python unitest/run_all_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68613c6769c8832581e4bd51ca54255b