### PR TITLE
Add feature extraction script for cleaned data

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,6 +49,26 @@ class PreprocessingOptions(BaseModel):
     bandpass_hz: List[int]
 
 
+class LibraryFeatureBlock(BaseModel):
+    """Configuration for a group of features from a library."""
+
+    enabled: bool = True
+    selected_features: List[str] = Field(default_factory=list)
+
+
+class MNEFeatureBlock(LibraryFeatureBlock):
+    freq_bands: Dict[str, List[float]] = Field(default_factory=dict)
+
+
+class FeatureCatalog(BaseModel):
+    """Root feature catalog configuration."""
+
+    enable_all: bool = True
+    mne_features: MNEFeatureBlock
+    librosa: LibraryFeatureBlock
+    custom: LibraryFeatureBlock
+
+
 class Config(BaseModel):
     """Root configuration model."""
 
@@ -56,6 +76,7 @@ class Config(BaseModel):
     runtime: RuntimeConfig
     datasets: List[DatasetConfig] = Field(default_factory=list)
     preprocessing_options: PreprocessingOptions
+    features: FeatureCatalog
 
 
 CONFIG_PATH = Path(__file__).with_name("config.yaml")

--- a/config.yaml
+++ b/config.yaml
@@ -46,27 +46,41 @@ preprocessing_options:
 # 4. Feature extraction catalogue (Phase 1)
 # -------------------------------------------------------------------
 features:
-  enable_all: true                                # If false, toggle individual blocks
-  available:
-    #  ⬇ Time‑domain statistics
-    - time_skewness
-    - time_kurtosis
-    - time_rms
-    - time_variance
-    - peak_to_peak
-    - zero_cross_rate
-    #  ⬇ Frequency‑domain statistics
-    - spectral_centroid
-    - spectral_bandwidth
-    - spectral_entropy
-    - dominant_frequency
-    #  ⬇ Wavelet / entropy family
-    - wavelet_energy
-    - wavelet_entropy
-    - wavelet_symlets_energy
-    - multiscale_entropy
-    #  ⬇ MFCCs for UHF acoustic PD sensors
-    - mfcc
+  enable_all: true
+  mne_features:
+    enabled: true
+    freq_bands:
+      delta: [0.5, 4.5]
+      theta: [4.5, 8.5]
+      alpha: [8.5, 11.5]
+      sigma: [11.5, 15.5]
+      beta:  [15.5, 30.0]
+    selected_features:
+      - line_length
+      - zero_crossings
+      - kurtosis
+      - rms
+  librosa:
+    enabled: true
+    selected_features:
+      - spectral_centroid
+      - spectral_bandwidth
+      - mfcc
+  custom:
+    enabled: true
+    selected_features:
+      - time_skewness
+      - time_kurtosis
+      - time_rms
+      - time_variance
+      - peak_to_peak
+      - zero_cross_rate
+      - spectral_entropy
+      - dominant_frequency
+      - wavelet_energy
+      - wavelet_entropy
+      - wavelet_symlets_energy
+      - multiscale_entropy
 
 # -------------------------------------------------------------------
 # 5. Modelling search‑space (Phase 2)

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -1,0 +1,7 @@
+"""Feature extraction utilities."""
+
+from .catalog import load_feature_catalog
+from . import extractors
+from .extract_from_clean import run as extract_from_clean
+
+__all__ = ["load_feature_catalog", "extractors", "extract_from_clean"]

--- a/features/catalog.py
+++ b/features/catalog.py
@@ -1,0 +1,45 @@
+"""Utilities to map feature names to extractor callables."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import config
+from . import extractors
+
+
+_EXTRACTOR_MAP = {
+    **{name: getattr(extractors, name) for name in dir(extractors) if name.startswith("compute_")},
+    "line_length": extractors.compute_line_length,
+    "zero_crossings": extractors.compute_zero_crossings,
+    "kurtosis": extractors.compute_kurtosis,
+    "rms": extractors.compute_rms,
+    "samp_entropy": extractors.compute_samp_entropy,
+}
+
+
+def load_feature_catalog() -> Dict[str, Callable]:
+    """Load enabled features from ``config.yaml``.
+
+    Returns
+    -------
+    Dict[str, Callable]
+        Mapping of feature name to extractor function.
+    """
+    feats_cfg = config.CONFIG.features
+    catalog: Dict[str, Callable] = {}
+
+    def _add_feats(names: list[str]) -> None:
+        for n in names:
+            func = _EXTRACTOR_MAP.get(f"compute_{n}", _EXTRACTOR_MAP.get(n))
+            if func:
+                catalog[n] = func
+
+    if feats_cfg.enable_all or feats_cfg.custom.enabled:
+        _add_feats(feats_cfg.custom.selected_features)
+    if feats_cfg.enable_all or feats_cfg.librosa.enabled:
+        _add_feats(feats_cfg.librosa.selected_features)
+    if feats_cfg.enable_all or feats_cfg.mne_features.enabled:
+        _add_feats(feats_cfg.mne_features.selected_features)
+
+    return catalog
+

--- a/features/extract_from_clean.py
+++ b/features/extract_from_clean.py
@@ -1,0 +1,129 @@
+"""Feature extraction from cleaned npy files.
+
+This module scans the project `root_dir` for folders named ``data_clean`` under
+individual stations. Each subdirectory represents a cleaning strategy (e.g.
+``standard_denoising_normalisation`` or ``advanced_denoising/VMD``). Every ``.npy``
+file contained within is loaded and processed by the feature catalog defined in
+:mod:`features.catalog`.
+
+For each cleaned file we save multiple Parquet files under ``2_feature_engineering``
+inside the ``outputs/features`` directory. The output hierarchy mirrors the cleaning
+strategy and groups features by theme, for example::
+
+    <root_dir>/outputs/features/<station>/classic_stats/advanced_denoising/VMD/<file>.parquet
+
+This design allows different preprocessing experiments to coexist while keeping
+features organised by theme and method.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict
+import inspect
+
+import pandas as pd
+import numpy as np
+from tqdm import tqdm
+
+import config
+from .catalog import load_feature_catalog
+
+# Map feature names to a thematic folder.
+_THEME_MAP: dict[str, list[str]] = {
+    "classic_stats": [
+        "time_skewness",
+        "time_kurtosis",
+        "time_rms",
+        "time_variance",
+        "peak_to_peak",
+        "zero_cross_rate",
+        "line_length",
+        "kurtosis",
+        "rms",
+        "zero_crossings",
+    ],
+    "time_frequency": [
+        "spectral_centroid",
+        "spectral_bandwidth",
+        "dominant_frequency",
+        "spectral_entropy",
+        "mfcc",
+    ],
+    "wavelet_cwt": [
+        "wavelet_energy",
+        "wavelet_entropy",
+        "wavelet_symlets_energy",
+    ],
+    "entropy_fractal": ["multiscale_entropy"],
+}
+
+
+def _call_extractor(func: Callable, window: np.ndarray, fs: float) -> float:
+    """Call ``func`` with ``window`` and ``fs`` when required."""
+    sig = inspect.signature(func)
+    kwargs = {}
+    if "fs" in sig.parameters:
+        kwargs["fs"] = fs
+    return float(func(window, **kwargs))
+
+
+def _process_file(npy_path: Path, catalog: Dict[str, Callable], fs: float) -> None:
+    """Compute features for one ``.npy`` file and save to Parquet.
+
+    Parameters
+    ----------
+    npy_path:
+        Path to a cleaned window stored under ``data_clean``.
+    catalog:
+        Mapping of feature names to extractor callables.
+    fs:
+        Sampling rate of the signal in Hz.
+    """
+    window = np.load(npy_path)
+    station_dir = npy_path.parents[2]
+    method_rel = npy_path.parent.relative_to(station_dir / "data_clean")
+    for theme, feature_names in _THEME_MAP.items():
+        rows = {}
+        for name in feature_names:
+            func = catalog.get(name)
+            if not func:
+                continue
+            try:
+                rows[name] = _call_extractor(func, window, fs)
+            except Exception:  # pragma: no cover - extractor failure
+                rows[name] = np.nan
+        if rows:
+            out_root = Path(config.CONFIG.project.features_dir)
+            out_dir = out_root / station_dir.name / theme / method_rel
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"{npy_path.stem}.parquet"
+            pd.DataFrame([rows]).to_parquet(out_path, index=False)
+
+
+def run(fs: float = 1.0) -> None:
+    """Extract features from all cleaned windows.
+
+    The function recursively scans ``CONFIG.project.root_dir`` for stations that
+    contain a ``data_clean`` folder. For every ``.npy`` file found, the feature
+    catalog is applied and results are written as Parquet files under
+    ``outputs/features/<station>`` grouped by theme and cleaning method.
+
+    Parameters
+    ----------
+    fs:
+        Sampling rate used for feature extractors requiring it.
+    """
+    catalog = load_feature_catalog()
+    root = Path(config.CONFIG.project.root_dir)
+    for station in root.iterdir():
+        data_clean = station / "data_clean"
+        if not data_clean.is_dir():
+            continue
+        npy_files = list(data_clean.rglob("*.npy"))
+        for npy_path in tqdm(npy_files, desc=station.name):
+            _process_file(npy_path, catalog, fs)
+
+
+if __name__ == "__main__":
+    run()

--- a/features/extractors.py
+++ b/features/extractors.py
@@ -1,0 +1,175 @@
+"""Base feature extractor functions for PD windows."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+from scipy import stats, signal
+import pywt
+
+try:
+    from mne_features.feature_extraction import extract_features
+    HAVE_MNE = True
+except Exception:  # pragma: no cover - optional dependency
+    HAVE_MNE = False
+
+try:
+    import librosa
+    HAVE_LIBROSA = True
+except Exception:  # pragma: no cover - optional dependency
+    HAVE_LIBROSA = False
+
+
+# ---------------------------------------------------------------------------
+# Custom time-domain statistics
+# ---------------------------------------------------------------------------
+
+def compute_time_skewness(window: np.ndarray) -> float:
+    """Return the skewness of the signal."""
+    return float(stats.skew(window))
+
+
+def compute_time_kurtosis(window: np.ndarray) -> float:
+    """Return the kurtosis of the signal."""
+    return float(stats.kurtosis(window))
+
+
+def compute_time_rms(window: np.ndarray) -> float:
+    """Return the root-mean-square of the signal."""
+    return float(np.sqrt(np.mean(np.square(window))))
+
+
+def compute_time_variance(window: np.ndarray) -> float:
+    """Return the variance of the signal."""
+    return float(np.var(window))
+
+
+def compute_peak_to_peak(window: np.ndarray) -> float:
+    """Return the peak-to-peak amplitude."""
+    return float(np.ptp(window))
+
+
+def compute_zero_cross_rate(window: np.ndarray) -> float:
+    """Return the rate of zero crossings."""
+    signs = np.sign(window)
+    return float(np.mean(signs[:-1] != signs[1:]))
+
+
+# ---------------------------------------------------------------------------
+# Frequency-domain statistics
+# ---------------------------------------------------------------------------
+
+def compute_spectral_centroid(window: np.ndarray, fs: float) -> float:
+    """Return the spectral centroid in Hz."""
+    if not HAVE_LIBROSA:
+        freqs, psd = signal.welch(window, fs=fs)
+        return float(np.sum(freqs * psd) / np.sum(psd))
+    centroid = librosa.feature.spectral_centroid(y=window, sr=int(fs))
+    return float(np.mean(centroid))
+
+
+def compute_spectral_bandwidth(window: np.ndarray, fs: float) -> float:
+    """Return the spectral bandwidth in Hz."""
+    if not HAVE_LIBROSA:
+        freqs, psd = signal.welch(window, fs=fs)
+        centroid = np.sum(freqs * psd) / np.sum(psd)
+        return float(np.sqrt(np.sum(psd * (freqs - centroid) ** 2) / np.sum(psd)))
+    bw = librosa.feature.spectral_bandwidth(y=window, sr=int(fs))
+    return float(np.mean(bw))
+
+
+def compute_spectral_entropy(window: np.ndarray, fs: float) -> float:
+    """Return the Shannon entropy of the power spectral density."""
+    freqs, psd = signal.welch(window, fs=fs)
+    psd_norm = psd / np.sum(psd)
+    return float(-np.sum(psd_norm * np.log(psd_norm + 1e-10)))
+
+
+def compute_dominant_frequency(window: np.ndarray, fs: float) -> float:
+    """Return the dominant frequency component in Hz."""
+    freqs, psd = signal.welch(window, fs=fs)
+    return float(freqs[np.argmax(psd)])
+
+
+# ---------------------------------------------------------------------------
+# Wavelet-based statistics
+# ---------------------------------------------------------------------------
+
+def compute_wavelet_energy(window: np.ndarray, wavelet: str = "db4", level: int = 3) -> float:
+    """Return the total wavelet energy across decomposition levels."""
+    coeffs = pywt.wavedec(window, wavelet, level=level)
+    energy = np.sum([np.sum(c ** 2) for c in coeffs])
+    return float(energy / len(window))
+
+
+def compute_wavelet_entropy(window: np.ndarray, wavelet: str = "db4", level: int = 3) -> float:
+    """Return the entropy of wavelet energies."""
+    coeffs = pywt.wavedec(window, wavelet, level=level)
+    energies = np.array([np.sum(c ** 2) for c in coeffs])
+    energies /= np.sum(energies)
+    return float(-np.sum(energies * np.log(energies + 1e-12)))
+
+
+def compute_wavelet_symlets_energy(window: np.ndarray, level: int = 3) -> float:
+    """Wavelet energy using Symlet basis."""
+    return compute_wavelet_energy(window, wavelet="sym5", level=level)
+
+
+def compute_multiscale_entropy(window: np.ndarray, scales: Iterable[int] | None = None) -> float:
+    """Approximate multiscale entropy using coarse-graining."""
+    if scales is None:
+        scales = range(1, 4)
+    entropies = []
+    for s in scales:
+        if s <= 1:
+            coarse = window
+        else:
+            coarse = window[: len(window) // s * s].reshape(-1, s).mean(axis=1)
+        entropies.append(compute_spectral_entropy(coarse, fs=1.0))
+    return float(np.mean(entropies))
+
+
+# ---------------------------------------------------------------------------
+# Librosa features
+# ---------------------------------------------------------------------------
+
+def compute_mfcc(window: np.ndarray, fs: float, n_mfcc: int = 13) -> float:
+    """Return the mean MFCC across coefficients."""
+    if not HAVE_LIBROSA:
+        raise ImportError("librosa is required for MFCC computation")
+    mfcc = librosa.feature.mfcc(y=window, sr=int(fs), n_mfcc=n_mfcc)
+    return float(np.mean(mfcc))
+
+
+# ---------------------------------------------------------------------------
+# Wrappers for mne-features
+# ---------------------------------------------------------------------------
+
+def _compute_mne_feature(window: np.ndarray, fs: float, feature: str) -> float:
+    """General helper to compute a feature via mne-features."""
+    if not HAVE_MNE:
+        raise ImportError("mne-features is required for this extractor")
+    data = window[np.newaxis, np.newaxis, :]
+    values = extract_features(data, fs, selected_funcs=[feature])
+    return float(values[0, 0])
+
+
+def compute_line_length(window: np.ndarray, fs: float) -> float:
+    return _compute_mne_feature(window, fs, "line_length")
+
+
+def compute_zero_crossings(window: np.ndarray, fs: float) -> float:
+    return _compute_mne_feature(window, fs, "zero_crossings")
+
+
+def compute_kurtosis(window: np.ndarray, fs: float) -> float:
+    return _compute_mne_feature(window, fs, "kurtosis")
+
+
+def compute_rms(window: np.ndarray, fs: float) -> float:
+    return _compute_mne_feature(window, fs, "rms")
+
+
+def compute_samp_entropy(window: np.ndarray, fs: float) -> float:
+    return _compute_mne_feature(window, fs, "samp_entropy")
+

--- a/notebooks/feature_catalog_tutorial.ipynb
+++ b/notebooks/feature_catalog_tutorial.ipynb
@@ -1,0 +1,129 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Feature Catalog and Selection Tutorial\n",
+        "\n",
+        "This tutorial demonstrates how to configure and select features from **mne-features**, **librosa**, and custom extractors defined in `features/extractors.py`.\n",
+        "We rely on the `config.yaml` file to enable or disable entire groups of features."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Loading the Configuration\n",
+        "The helper `config.load_config` reads `config.yaml` and validates the structure via pydantic models."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pprint\n",
+        "import config\n",
+        "from features import load_feature_catalog\n",
+        "\n",
+        "cfg = config.load_config()\n",
+        "pprint.pp(cfg.features.model_dump())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Building the Catalog\n",
+        "The function `load_feature_catalog` uses the configuration to return a dictionary mapping feature names to extractor callables."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "catalog = load_feature_catalog()\n",
+        "list(catalog.keys())[:10]  # preview"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Selecting Specific Libraries\n",
+        "You can disable an entire block (e.g. `librosa`) by setting `enabled: false` in the `config.yaml` section. When `enable_all` is `false`, only the libraries explicitly enabled will be added."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "cfg.features.librosa.enabled = False\n",
+        "catalog = load_feature_catalog()\n",
+        "sorted(catalog)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Computing Features\n",
+        "Each extractor takes a 1-D NumPy array (window) and the sampling rate `fs` when required."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "from unitest.fixtures.synthetic_pd import generate_synthetic_partial_discharge\n",
+        "\n",
+        "sample = generate_synthetic_partial_discharge(num_good=1, num_fault=0, length=256)\n",
+        "window = sample.iloc[0, :-1].to_numpy(float)\n",
+        "line_length = catalog['line_length'](window, fs=256.0)\n",
+        "line_length"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Batch Extraction from Cleaned Data\n",
+        "The helper function `features.extract_from_clean()` scans `root_dir` for cleaned windows and saves features under `2_feature_engineering/` grouped by theme and cleaning method."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+  "from features import extract_from_clean\n",
+  "\n",
+  "# This will write Parquet feature files into outputs/features/*\n",
+  "extract_from_clean(fs=256.0)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "vmdpy",
     "PyWavelets",
     "tsaug",
+    "mne-features",
+    "librosa",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ featurewiz
 numpy
 scipy
 mne
+mne-features
+librosa
 tqdm
 pyyaml
 pydantic

--- a/unitest/test_features.py
+++ b/unitest/test_features.py
@@ -1,0 +1,35 @@
+"""Tests for feature extractors."""
+
+import numpy as np
+
+from unitest.fixtures.synthetic_pd import generate_synthetic_partial_discharge
+from features import extractors
+
+
+def _get_window() -> np.ndarray:
+    df = generate_synthetic_partial_discharge(num_good=1, num_fault=0, length=64)
+    return df.iloc[0, :-1].to_numpy(float)
+
+
+def test_time_skewness_small() -> None:
+    w = _get_window()
+    val = extractors.compute_time_skewness(w)
+    assert abs(val) < 1.0
+
+
+def test_spectral_centroid_range() -> None:
+    w = _get_window()
+    val = extractors.compute_spectral_centroid(w, fs=64.0)
+    assert 0.0 <= val <= 32.0
+
+
+def test_mne_line_length_positive() -> None:
+    w = _get_window()
+    val = extractors.compute_line_length(w, fs=64.0)
+    assert val > 0.0
+
+
+def test_librosa_mfcc_finite() -> None:
+    w = _get_window()
+    val = extractors.compute_mfcc(w, fs=64.0)
+    assert np.isfinite(val)


### PR DESCRIPTION
## Summary
- implement `extract_from_clean` to compute features for each cleaned window and save into themed folders
- expose new helper via `features.__init__`
- document batch extraction in the feature catalog tutorial notebook
- save feature outputs as Parquet under `outputs/features`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614a00b1b48325a57dad4a6260b56d