### PR TITLE
Add experiment runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,12 @@ Run all unit tests with:
 python unitest/run_all_test.py
 ```
 
+### Experiment runner
+
+Predefined experiment tracks are available via `experiments.tracks`. Execute all steps for a given dataset using:
+
+```bash
+python -m experiments.tracks run_experiment exp1_featurewiz dataset/contactless_pd_detection
+```
+
+Each track toggles options such as advanced denoising or augmentation as described in the code.

--- a/experiments/__init__.py
+++ b/experiments/__init__.py
@@ -1,0 +1,5 @@
+"""Predefined experiment configurations for the PD pipeline."""
+
+from .tracks import EXPERIMENTS, ExperimentTrack, run_experiment
+
+__all__ = ["EXPERIMENTS", "ExperimentTrack", "run_experiment"]

--- a/experiments/tracks.py
+++ b/experiments/tracks.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Utilities to run predefined experiment tracks."""
+
+import logging
+from dataclasses import dataclass
+
+from preprocess import run_preprocess
+from features import extract_from_clean
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExperimentTrack:
+    """Configuration for a single experiment run."""
+
+    name: str
+    advanced_denoise: bool = False
+    augment: bool = False
+    wavelet_feats: bool = False
+
+    def run(self, dataset: str, jobs: int = 1, force: bool = False) -> None:
+        """Execute preprocessing and feature extraction for ``dataset``."""
+        logger.info("Running %s", self.name)
+        run_preprocess.run(
+            dataset,
+            force=force,
+            adv_denoise=self.advanced_denoise,
+            augment=self.augment,
+            jobs=jobs,
+        )
+        extract_from_clean.run()
+        logger.info("%s complete", self.name)
+
+
+EXPERIMENTS: dict[str, ExperimentTrack] = {
+    "exp1_featurewiz": ExperimentTrack(
+        name="Featurewiz Track",
+        advanced_denoise=False,
+        augment=False,
+        wavelet_feats=False,
+    ),
+    "exp2_mljar": ExperimentTrack(
+        name="MLJAR-Supervised",
+        advanced_denoise=False,
+        augment=False,
+        wavelet_feats=False,
+    ),
+    "exp3_borutashap": ExperimentTrack(
+        name="Advanced Denoising + BorutaShap",
+        advanced_denoise=True,
+        augment=False,
+        wavelet_feats=False,
+    ),
+    "exp4_catboost": ExperimentTrack(
+        name="Data Augmentation + CatBoost",
+        advanced_denoise=False,
+        augment=True,
+        wavelet_feats=False,
+    ),
+    "exp5_wavelet_cnn": ExperimentTrack(
+        name="Wavelet Image CNN",
+        advanced_denoise=False,
+        augment=False,
+        wavelet_feats=True,
+    ),
+}
+
+
+def run_experiment(name: str, dataset: str, jobs: int = 1, force: bool = False) -> None:
+    """Run the experiment specified by ``name``."""
+    track = EXPERIMENTS[name]
+    track.run(dataset=dataset, jobs=jobs, force=force)
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run predefined experiment tracks")
+    parser.add_argument("experiment", choices=EXPERIMENTS.keys())
+    parser.add_argument("dataset")
+    parser.add_argument("--jobs", type=int, default=1)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    run_experiment(args.experiment, dataset=args.dataset, jobs=args.jobs, force=args.force)

--- a/unitest/test_experiments.py
+++ b/unitest/test_experiments.py
@@ -1,0 +1,12 @@
+"""Tests for experiment configurations."""
+
+from experiments import EXPERIMENTS, ExperimentTrack
+
+
+def test_experiment_count() -> None:
+    assert len(EXPERIMENTS) == 5
+
+
+def test_experiment_instances() -> None:
+    for exp in EXPERIMENTS.values():
+        assert isinstance(exp, ExperimentTrack)


### PR DESCRIPTION
## Summary
- implement `experiments.tracks` module defining experiment configurations
- expose CLI to run a track and add unit tests
- document experiment runner usage

## Testing
- `python unitest/run_all_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68707c1441948325be8fcac042b60415